### PR TITLE
refactor: replace unsupported spindle inputs

### DIFF
--- a/app/(home)/page.tsx
+++ b/app/(home)/page.tsx
@@ -2,7 +2,8 @@
 
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
-import { Button, Input } from '@openameba/spindle-ui';
+import { Button } from '@openameba/spindle-ui';
+import { Input } from '@/components/ui/input';
 import { X, BookOpen } from 'lucide-react';
 import { useStore, Book } from '@/lib/store';
 import { exportAsTxt } from '@/lib/file';
@@ -144,7 +145,7 @@ export default function HomePage() {
             title={query ? '検索結果が見つかりません' : 'ブックがありません'}
             description={query ? '別のキーワードで検索してみてください' : '新しいブックを作成して執筆を始めましょう'}
             action={
-              <Button variant="primary" onClick={handleNewBook}>
+              <Button variant="contained" onClick={handleNewBook}>
                 新しいブックを作成
               </Button>
             }
@@ -172,10 +173,9 @@ export default function HomePage() {
             <div className="flex justify-between items-center mb-4">
               <h3 className="text-lg font-semibold">新しいブックを作成</h3>
               <Button
-                variant="ghost"
-                size="sm"
+                variant="lighted"
+                size="small"
                 onClick={() => setShowNewBookDialog(false)}
-                className="p-1"
               >
                 <X className="w-4 h-4" />
               </Button>
@@ -199,13 +199,13 @@ export default function HomePage() {
 
               <div className="flex gap-2 justify-end">
                 <Button
-                  variant="ghost"
+                  variant="lighted"
                   onClick={() => setShowNewBookDialog(false)}
                 >
                   キャンセル
                 </Button>
                 <Button
-                  variant="primary"
+                  variant="contained"
                   onClick={handleCreateBook}
                   disabled={!newBookTitle.trim()}
                 >

--- a/app/book/[id]/page.tsx
+++ b/app/book/[id]/page.tsx
@@ -112,10 +112,9 @@ export default function EditorPage() {
         <div className="p-3 border-b border-gray-200 flex justify-between items-center">
           <h2 className="font-semibold">辞書・資料</h2>
           <Button
-            variant="ghost"
-            size="sm"
+            variant="lighted"
+            size="small"
             onClick={() => setRightPanelOpen(false)}
-            className="p-1"
           >
             <X className="w-4 h-4" />
           </Button>
@@ -180,10 +179,9 @@ export default function EditorPage() {
         {/* タブレット用右パネル開閉ボタン */}
         {isTablet && (
           <Button
-            variant="ghost"
-            size="sm"
+            variant="lighted"
+            size="small"
             onClick={() => setRightPanelOpen(!ui.rightPanelOpen)}
-            className="mr-4"
           >
             <Menu className="w-5 h-5" />
           </Button>

--- a/components/Chat/Composer.tsx
+++ b/components/Chat/Composer.tsx
@@ -52,9 +52,8 @@ export default function Composer({ onSend, disabled = false, placeholder = "ãƒ¡ã
         <Button
           onClick={handleSubmit}
           disabled={!content.trim() || disabled || isSubmitting}
-          variant="primary"
-          size="sm"
-          className="px-3 self-end"
+          variant="contained"
+          size="small"
         >
           {isSubmitting ? (
             <div className="w-4 h-4 border-2 border-white border-t-transparent rounded-full animate-spin" />

--- a/components/Editor/RichEditor.tsx
+++ b/components/Editor/RichEditor.tsx
@@ -3,7 +3,8 @@
 import { useEditor, EditorContent } from '@tiptap/react';
 import StarterKit from '@tiptap/starter-kit';
 import { useEffect, useState, useCallback } from 'react';
-import { Button, Input } from '@openameba/spindle-ui';
+import { Button } from '@openameba/spindle-ui';
+import { Input } from '@/components/ui/input';
 import {
   Bold,
   Italic,
@@ -128,20 +129,18 @@ export default function RichEditor({ bookId }: RichEditorProps) {
       <div className="p-3 border-b border-gray-200 bg-gray-50 flex flex-wrap gap-1">
         {/* 基本装飾 */}
         <Button
-          variant={editor.isActive('bold') ? 'primary' : 'ghost'}
-          size="sm"
+          variant={editor.isActive('bold') ? 'contained' : 'lighted'}
+          size="small"
           onClick={() => editor.chain().focus().toggleBold().run()}
-          className="p-2"
           title="太字 (Ctrl+B)"
         >
           <Bold className="w-4 h-4" />
         </Button>
         
         <Button
-          variant={editor.isActive('italic') ? 'primary' : 'ghost'}
-          size="sm"
+          variant={editor.isActive('italic') ? 'contained' : 'lighted'}
+          size="small"
           onClick={() => editor.chain().focus().toggleItalic().run()}
-          className="p-2"
           title="斜体 (Ctrl+I)"
         >
           <Italic className="w-4 h-4" />
@@ -151,30 +150,27 @@ export default function RichEditor({ bookId }: RichEditorProps) {
 
         {/* 見出し */}
         <Button
-          variant={editor.isActive('heading', { level: 1 }) ? 'primary' : 'ghost'}
-          size="sm"
+          variant={editor.isActive('heading', { level: 1 }) ? 'contained' : 'lighted'}
+          size="small"
           onClick={() => editor.chain().focus().toggleHeading({ level: 1 }).run()}
-          className="p-2"
           title="見出し1"
         >
           <Heading1 className="w-4 h-4" />
         </Button>
         
         <Button
-          variant={editor.isActive('heading', { level: 2 }) ? 'primary' : 'ghost'}
-          size="sm"
+          variant={editor.isActive('heading', { level: 2 }) ? 'contained' : 'lighted'}
+          size="small"
           onClick={() => editor.chain().focus().toggleHeading({ level: 2 }).run()}
-          className="p-2"
           title="見出し2"
         >
           <Heading2 className="w-4 h-4" />
         </Button>
         
         <Button
-          variant={editor.isActive('heading', { level: 3 }) ? 'primary' : 'ghost'}
-          size="sm"
+          variant={editor.isActive('heading', { level: 3 }) ? 'contained' : 'lighted'}
+          size="small"
           onClick={() => editor.chain().focus().toggleHeading({ level: 3 }).run()}
-          className="p-2"
           title="見出し3"
         >
           <Heading3 className="w-4 h-4" />
@@ -184,20 +180,18 @@ export default function RichEditor({ bookId }: RichEditorProps) {
 
         {/* リスト */}
         <Button
-          variant={editor.isActive('bulletList') ? 'primary' : 'ghost'}
-          size="sm"
+          variant={editor.isActive('bulletList') ? 'contained' : 'lighted'}
+          size="small"
           onClick={() => editor.chain().focus().toggleBulletList().run()}
-          className="p-2"
           title="箇条書き"
         >
           <List className="w-4 h-4" />
         </Button>
         
         <Button
-          variant={editor.isActive('orderedList') ? 'primary' : 'ghost'}
-          size="sm"
+          variant={editor.isActive('orderedList') ? 'contained' : 'lighted'}
+          size="small"
           onClick={() => editor.chain().focus().toggleOrderedList().run()}
-          className="p-2"
           title="番号付きリスト"
         >
           <ListOrdered className="w-4 h-4" />
@@ -207,20 +201,18 @@ export default function RichEditor({ bookId }: RichEditorProps) {
 
         {/* その他 */}
         <Button
-          variant={editor.isActive('blockquote') ? 'primary' : 'ghost'}
-          size="sm"
+          variant={editor.isActive('blockquote') ? 'contained' : 'lighted'}
+          size="small"
           onClick={() => editor.chain().focus().toggleBlockquote().run()}
-          className="p-2"
           title="引用"
         >
           <Quote className="w-4 h-4" />
         </Button>
         
         <Button
-          variant={editor.isActive('code') ? 'primary' : 'ghost'}
-          size="sm"
+          variant={editor.isActive('code') ? 'contained' : 'lighted'}
+          size="small"
           onClick={() => editor.chain().focus().toggleCode().run()}
-          className="p-2"
           title="コード"
         >
           <Code className="w-4 h-4" />
@@ -230,10 +222,9 @@ export default function RichEditor({ bookId }: RichEditorProps) {
 
         {/* ルビ振り */}
         <Button
-          variant="ghost"
-          size="sm"
+          variant="lighted"
+          size="small"
           onClick={handleAddRuby}
-          className="p-2"
           title="ルビ振り"
           disabled={!editor.state.selection.empty === false}
         >
@@ -244,10 +235,9 @@ export default function RichEditor({ bookId }: RichEditorProps) {
 
         {/* Undo/Redo */}
         <Button
-          variant="ghost"
-          size="sm"
+          variant="lighted"
+          size="small"
           onClick={() => editor.chain().focus().undo().run()}
-          className="p-2"
           title="元に戻す"
           disabled={!editor.can().undo()}
         >
@@ -255,10 +245,9 @@ export default function RichEditor({ bookId }: RichEditorProps) {
         </Button>
         
         <Button
-          variant="ghost"
-          size="sm"
+          variant="lighted"
+          size="small"
           onClick={() => editor.chain().focus().redo().run()}
-          className="p-2"
           title="やり直し"
           disabled={!editor.can().redo()}
         >
@@ -285,10 +274,9 @@ export default function RichEditor({ bookId }: RichEditorProps) {
             <div className="flex justify-between items-center mb-4">
               <h3 className="text-lg font-semibold">ルビ振り</h3>
               <Button
-                variant="ghost"
-                size="sm"
+                variant="lighted"
+                size="small"
                 onClick={() => setShowRubyModal(false)}
-                className="p-1"
               >
                 <X className="w-4 h-4" />
               </Button>
@@ -315,18 +303,23 @@ export default function RichEditor({ bookId }: RichEditorProps) {
               </div>
 
               <div className="text-sm text-gray-600">
-                プレビュー: <ruby><rb>{selectedText}</rb><rt>{rubyText}</rt></ruby>
+                プレビュー:{' '}
+                <span
+                  dangerouslySetInnerHTML={{
+                    __html: `<ruby><rb>${selectedText}</rb><rt>${rubyText}</rt></ruby>`
+                  }}
+                />
               </div>
 
               <div className="flex gap-2 justify-end">
                 <Button
-                  variant="ghost"
+                  variant="lighted"
                   onClick={() => setShowRubyModal(false)}
                 >
                   キャンセル
                 </Button>
                 <Button
-                  variant="primary"
+                  variant="contained"
                   onClick={applyRuby}
                   disabled={!rubyText.trim()}
                 >

--- a/components/Editor/TitleBar.tsx
+++ b/components/Editor/TitleBar.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import { Input } from '@openameba/spindle-ui';
+import { Input } from '@/components/ui/input';
 import { useStore } from '@/lib/store';
 
 interface TitleBarProps {
@@ -75,8 +75,7 @@ export default function TitleBar({ bookId }: TitleBarProps) {
           value={title}
           onChange={(e) => setTitle(e.target.value)}
           placeholder="タイトルを入力..."
-          className="flex-1 text-lg font-medium"
-          variant="standard"
+          className="flex-1 text-lg font-medium border-none focus:ring-0"
         />
         
         <div className={`text-sm font-medium ${getSaveStatusColor()}`}>

--- a/components/Header.tsx
+++ b/components/Header.tsx
@@ -32,9 +32,8 @@ export default function Header() {
 
       <div className="flex items-center gap-2">
         <Button
-          variant="ghost"
-          size="sm"
-          className="p-2"
+          variant="lighted"
+          size="small"
           aria-label="ヘルプ"
         >
           <HelpCircle className="w-5 h-5" />

--- a/components/Left/SourceManager.tsx
+++ b/components/Left/SourceManager.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState, useRef, useCallback } from 'react';
-import { Button, Input } from '@openameba/spindle-ui';
+import { Button } from '@openameba/spindle-ui';
+import { Input } from '@/components/ui/input';
 import { Upload, Search, ChevronDown } from 'lucide-react';
 import { useStore, Episode } from '@/lib/store';
 import { extractText } from '@/lib/file';
@@ -159,7 +160,7 @@ export default function SourceManager({ bookId }: SourceManagerProps) {
             placeholder="ソースを検索..."
             value={searchQuery}
             onChange={(e) => setSearchQuery(e.target.value)}
-            size="sm"
+            className="h-8 text-sm"
           />
           
           <div className="flex gap-2">
@@ -173,16 +174,16 @@ export default function SourceManager({ bookId }: SourceManagerProps) {
               <option value="title">タイトル順</option>
             </select>
             <Button
-              variant="ghost"
-              size="sm"
+              variant="lighted"
+              size="small"
               onClick={handleSelectAll}
               disabled={bookEpisodes.length === 0}
             >
               全選択
             </Button>
             <Button
-              variant="ghost"
-              size="sm"
+              variant="lighted"
+              size="small"
               onClick={handleSelectNone}
               disabled={activeSourceIds.length === 0}
             >
@@ -221,11 +222,10 @@ export default function SourceManager({ bookId }: SourceManagerProps) {
             {activeSourceIds.length}件選択中
           </span>
           <Button
-            variant="primary"
-            size="sm"
+            variant="contained"
+            size="small"
             onClick={handleSearch}
             disabled={activeSourceIds.length === 0}
-            className="flex items-center gap-2"
           >
             <Search className="w-4 h-4" />
             検索

--- a/components/Right/DictionarySearch.tsx
+++ b/components/Right/DictionarySearch.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState, useCallback } from 'react';
-import { Button, Input } from '@openameba/spindle-ui';
+import { Button } from '@openameba/spindle-ui';
+import { Input } from '@/components/ui/input';
 import { Search, Book, Tag } from 'lucide-react';
 import ChatWindow from '../Chat/ChatWindow';
 import Composer from '../Chat/Composer';
@@ -123,9 +124,8 @@ export default function DictionarySearch({ bookId }: DictionarySearchProps) {
           <Button
             onClick={handleSearch}
             disabled={!searchQuery.trim() || isSearching}
-            variant="primary"
-            size="sm"
-            className="px-4"
+            variant="contained"
+            size="small"
           >
             <Search className="w-4 h-4" />
           </Button>

--- a/components/Right/MaterialUpload.tsx
+++ b/components/Right/MaterialUpload.tsx
@@ -146,15 +146,15 @@ export default function MaterialUpload({ bookId }: MaterialUploadProps) {
           <div className="flex gap-2 justify-between items-center">
             <div className="flex gap-2">
               <Button
-                variant="ghost"
-                size="sm"
+                variant="lighted"
+                size="small"
                 onClick={handleSelectAll}
               >
                 全選択
               </Button>
               <Button
-                variant="ghost"
-                size="sm"
+                variant="lighted"
+                size="small"
                 onClick={handleSelectNone}
                 disabled={activeMaterialIds.length === 0}
               >
@@ -228,13 +228,12 @@ export default function MaterialUpload({ bookId }: MaterialUploadProps) {
 
                   {/* 削除ボタン */}
                   <Button
-                    variant="ghost"
-                    size="sm"
+                    variant="lighted"
+                    size="small"
                     onClick={(e) => {
                       e.stopPropagation();
                       handleDeleteMaterial(material.id);
                     }}
-                    className="p-1 text-red-600 hover:bg-red-50"
                   >
                     <X className="w-4 h-4" />
                   </Button>

--- a/components/home/BookGrid.tsx
+++ b/components/home/BookGrid.tsx
@@ -13,24 +13,7 @@ interface BookGridProps {
 
 export default function BookGrid({ books, onBookClick, onBookAction, onNewBook }: BookGridProps) {
   return (
-    <div className="grid gap-6 p-6" style={{
-      gridTemplateColumns: 'repeat(auto-fit, minmax(312px, 1fr))',
-      '@media (min-width: 1536px)': {
-        gridTemplateColumns: 'repeat(5, 1fr)'
-      },
-      '@media (min-width: 1280px) and (max-width: 1535px)': {
-        gridTemplateColumns: 'repeat(4, 1fr)'
-      },
-      '@media (min-width: 1024px) and (max-width: 1279px)': {
-        gridTemplateColumns: 'repeat(3, 1fr)'
-      },
-      '@media (min-width: 768px) and (max-width: 1023px)': {
-        gridTemplateColumns: 'repeat(2, 1fr)'
-      },
-      '@media (max-width: 767px)': {
-        gridTemplateColumns: '1fr'
-      }
-    }}>
+    <div className="grid gap-6 p-6 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 2xl:grid-cols-5">
       <NewBookCard onClick={onNewBook} />
       
       {books.map((book) => (

--- a/components/home/Toolbar.tsx
+++ b/components/home/Toolbar.tsx
@@ -1,7 +1,8 @@
 'use client';
 
 import { useState } from 'react';
-import { Button, Input } from '@openameba/spindle-ui';
+import { Button } from '@openameba/spindle-ui';
+import { Input } from '@/components/ui/input';
 import { Search, Grid, List, ArrowUpDown, Plus } from 'lucide-react';
 import { useStore } from '@/lib/store';
 
@@ -58,27 +59,24 @@ export default function Toolbar({ onNewBook }: ToolbarProps) {
               onChange={(e) => setQuery(e.target.value)}
               onKeyDown={handleSearchKeyDown}
               placeholder="ブックを検索... (/ でフォーカス)"
-              className="w-80 pl-10 pr-4"
-              size="sm"
+              className="w-80 pl-10 pr-4 h-8 text-sm"
             />
           </div>
 
           {/* 表示切替 */}
           <div className="flex border border-gray-300 rounded-lg overflow-hidden">
             <Button
-              variant={viewMode === 'grid' ? 'primary' : 'ghost'}
-              size="sm"
+              variant={viewMode === 'grid' ? 'contained' : 'lighted'}
+              size="small"
               onClick={() => setViewMode('grid')}
-              className="rounded-none px-3"
               title="グリッド表示"
             >
               <Grid className="w-4 h-4" />
             </Button>
             <Button
-              variant={viewMode === 'list' ? 'primary' : 'ghost'}
-              size="sm"
+              variant={viewMode === 'list' ? 'contained' : 'lighted'}
+              size="small"
               onClick={() => setViewMode('list')}
-              className="rounded-none px-3 border-l border-gray-300"
               title="リスト表示"
             >
               <List className="w-4 h-4" />
@@ -88,10 +86,9 @@ export default function Toolbar({ onNewBook }: ToolbarProps) {
           {/* 並び替え */}
           <div className="relative">
             <Button
-              variant="ghost"
-              size="sm"
+              variant="lighted"
+              size="small"
               onClick={() => setShowSortMenu(!showSortMenu)}
-              className="flex items-center gap-2 px-3"
             >
               <ArrowUpDown className="w-4 h-4" />
               {currentSortLabel}
@@ -119,10 +116,9 @@ export default function Toolbar({ onNewBook }: ToolbarProps) {
 
           {/* 新規作成ボタン */}
           <Button
-            variant="primary"
-            size="sm"
+            variant="contained"
+            size="small"
             onClick={onNewBook}
-            className="flex items-center gap-2 px-4"
           >
             <Plus className="w-4 h-4" />
             新規作成

--- a/tests/editor.spec.ts
+++ b/tests/editor.spec.ts
@@ -52,7 +52,7 @@ test.describe('エディタ画面', () => {
       await expect(assistantMessage).toContainText('参照されたソース');
     } else {
       // ソースがない場合はテストをスキップ
-      test.skip('テスト用のソースデータがありません');
+      test.skip(true, 'テスト用のソースデータがありません');
     }
   });
 


### PR DESCRIPTION
## Summary
- replace Spindle `Input` references with local component
- align Spindle `Button` props with supported variants and sizes
- tidy tests and ruby preview rendering

## Testing
- `npx tsc -p tsconfig.json --noEmit`
- `npx playwright test` *(fails: browsers missing)*

------
https://chatgpt.com/codex/tasks/task_e_68a80655700c832aab5166c78dadd218